### PR TITLE
Fix logship fault with fields

### DIFF
--- a/tagalog/command/logship.py
+++ b/tagalog/command/logship.py
@@ -4,7 +4,7 @@ import json
 import sys
 import textwrap
 
-from tagalog import io, stamp, tag
+from tagalog import io, stamp, tag, fields
 from tagalog import shipper
 
 parser = argparse.ArgumentParser(description=textwrap.dedent("""


### PR DESCRIPTION
Logship.py was missing an include, which I've now fixed. 

I will next look to see if it could have been caught automatically. 
