### PR TITLE
Import fields in logship.py 

### DIFF
--- a/tagalog/command/logship.py
+++ b/tagalog/command/logship.py
@@ -4,7 +4,7 @@ import json
 import sys
 import textwrap
 
-from tagalog import io, stamp, tag
+from tagalog import io, stamp, tag, fields
 from tagalog import shipper
 
 parser = argparse.ArgumentParser(description=textwrap.dedent("""


### PR DESCRIPTION
Running govuk_logpipe with the -f argument currently fails:

$ govuk_logpipe  -f host=foo.bar.com application=mongodb
Traceback (most recent call last):
  File "/usr/local/bin/logship", line 9, in <module>
    load_entry_point('tagalog==0.2.3', 'console_scripts', 'logship')()
  File "/usr/local/lib/python2.6/dist-packages/tagalog/command/logship.py", line 41, in main
    msgs = fields(msgs, args.fields)
NameError: global name 'fields' is not defined

This is because logship.py does not currently import fields from **init**.py

This commit fixes that...
